### PR TITLE
overlay to display data

### DIFF
--- a/Earthquakes_past7days/index.html
+++ b/Earthquakes_past7days/index.html
@@ -31,8 +31,11 @@
 
     <!-- Our cities data-->
     <script type="text/javascript" src="static/js/cities.js"></script>
-    <script type="text/javascript" src="static/js/logicStep3.js"></script>
-    
+    <!-- <script type="text/javascript" src="static/js/logicStep1.js"></script> -->
+    <!-- <script type="text/javascript" src="static/js/logicStep2.js"></script> -->
+    <!-- <script type="text/javascript" src="static/js/logicStep3.js"></script> -->
+    <script type="text/javascript" src="static/js/logicStep4.js"></script>
+
 
 </body>
 </html>

--- a/Earthquakes_past7days/static/js/logicStep4.js
+++ b/Earthquakes_past7days/static/js/logicStep4.js
@@ -1,0 +1,124 @@
+// Add console.log to check to see if our code is working.
+console.log("working");
+
+let streets = L.tileLayer('https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}?access_token={accessToken}', {
+attribution: 'Map data © <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery (c) <a href="https://www.mapbox.com/">Mapbox</a>',
+    maxZoom: 18,
+    accessToken: API_KEY
+});
+
+let satelliteStreets = L.tileLayer('https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v11/tiles/{z}/{x}/{y}?access_token={accessToken}', {
+attribution: 'Map data © <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery (c) <a href="https://www.mapbox.com/">Mapbox</a>',
+    maxZoom: 18,
+    accessToken: API_KEY
+});
+
+// We create the dark view tile layer that will be an option for our map.
+let dark = L.tileLayer('https://api.mapbox.com/styles/v1/mapbox/dark-v10/tiles/{z}/{x}/{y}?access_token={accessToken}', {
+attribution: 'Map data © <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery (c) <a href="https://www.mapbox.com/">Mapbox</a>',
+    maxZoom: 18,
+    accessToken: API_KEY
+});
+
+// We create the tile layer that will be the background of our map.
+let light = L.tileLayer('https://api.mapbox.com/styles/v1/mapbox/light-v10/tiles/{z}/{x}/{y}?access_token={accessToken}', {
+attribution: 'Map data © <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery (c) <a href="https://www.mapbox.com/">Mapbox</a>',
+    maxZoom: 18,
+    accessToken: API_KEY
+});
+
+// Create a base layer that holds both maps.
+let baseMaps = {
+  Satellite: satelliteStreets,
+  Streets: streets,
+  Dark: dark,
+  Light: light
+};
+
+// Create the map object with center, zoom level and default layer.
+let map = L.map('mapid', {
+  center: [39.5, -98.5],
+  zoom: 3,
+  layers: [streets] 
+})
+
+// Pass our map layers into our layers control and add the layers control to the map.
+L.control.layers(baseMaps).addTo(map);
+
+// Then we add our 'graymap' tile layer to the map.
+// light.addTo(map);
+
+// Accessing the Toronto airline routes GeoJSON URL.
+let earthquakes = "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_week.geojson";
+
+// Create a style for the lines.
+let myStyle = {
+  fillColor: "#ffffa1",
+  weight: 1
+}
+
+// Grabbing our GeoJSON data.
+d3.json(earthquakes).then(function(data) {
+  console.log(data);
+// This function returns the style data for each of the earthquakes we plot on
+// the map. We pass the magnitude of the earthquake into a function
+// to calculate the radius.
+function styleInfo(feature) {
+  return {
+    opacity: 1,
+    fillOpacity: 1,
+    fillColor: getColor(feature.properties.mag),
+    color: "#000000",
+    radius: getRadius(feature.properties.mag),
+    stroke: true,
+    weight: 0.5
+  };
+}
+
+// This function determines the radius of the earthquake marker based on its magnitude.
+// Earthquakes with a magnitude of 0 will be plotted with a radius of 1.
+function getRadius(magnitude) {
+  if (magnitude === 0) {
+    return 1;
+  }
+  return magnitude * 4;
+}
+
+// This function determines the color of the circle based on the magnitude of the earthquake.
+function getColor(magnitude) {
+  if (magnitude > 5) {
+    return "#ea2c2c";
+  }
+  if (magnitude > 4) {
+    return "#ea822c";
+  }
+  if (magnitude > 3) {
+    return "#ee9c00";
+  }
+  if (magnitude > 2) {
+    return "#eecc00";
+  }
+  if (magnitude > 1) {
+    return "#d4ee00";
+  }
+  return "#98ee00";
+}
+
+// Creating a GeoJSON layer with the retrieved data.
+L.geoJSON(data, {
+
+  // We turn each feature into a circleMarker on the map.
+  
+  pointToLayer: function(feature, latlng) {
+              console.log(data);
+              return L.circleMarker(latlng);
+          },
+          // We set the style for each circleMarker using our styleInfo function.
+        style: styleInfo,
+        // We create a popup for each circleMarker to display the magnitude and
+        //  location of the earthquake after the marker has been created and styled.
+        onEachFeature: function(feature, layer) {
+        layer.bindPopup("Magnitude: " + feature.properties.mag + "<br>Location: " + feature.properties.place);
+      }
+      }).addTo(map);
+  });


### PR DESCRIPTION
add earthquake data as an overlay on both the Streets and Satellite tile layers so users can turn the data on and off